### PR TITLE
adapt for required api_key

### DIFF
--- a/delphi_epidata/_endpoints.py
+++ b/delphi_epidata/_endpoints.py
@@ -33,11 +33,11 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
     ) -> CALL_TYPE:
         raise NotImplementedError()
 
-    def afhsb(self, auth: str, locations: StringParam, epiweeks: EpiRangeParam, flu_types: StringParam) -> CALL_TYPE:
+    def afhsb(self, locations: StringParam, epiweeks: EpiRangeParam, flu_types: StringParam) -> CALL_TYPE:
         """Fetch AFHSB data (point data, no min/max)."""
 
-        if auth is None or locations is None or epiweeks is None or flu_types is None:
-            raise InvalidArgumentException("`auth`, `locations`, `epiweeks` and `flu_types` are all required")
+        if locations is None or epiweeks is None or flu_types is None:
+            raise InvalidArgumentException("`locations`, `epiweeks` and `flu_types` are all required")
 
         loc_exception = (
             "Location parameter  `{}` is invalid. Valid `location` parameters are: "
@@ -67,7 +67,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
 
         return self._create_call(
             "afhsb/",
-            dict(auth=auth, locations=locations, epiweeks=epiweeks, flu_types=flu_types),
+            dict(locations=locations, epiweeks=epiweeks, flu_types=flu_types),
             [
                 EpidataFieldInfo("location", EpidataFieldType.text),
                 EpidataFieldInfo("flu_type", EpidataFieldType.text),
@@ -76,15 +76,15 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def cdc(self, auth: str, epiweeks: EpiRangeParam, locations: StringParam) -> CALL_TYPE:
+    def cdc(self, epiweeks: EpiRangeParam, locations: StringParam) -> CALL_TYPE:
         """Fetch CDC page hits."""
 
-        if auth is None or epiweeks is None or locations is None:
-            raise InvalidArgumentException("`auth`, `epiweeks`, and `locations` are all required")
+        if epiweeks is None or locations is None:
+            raise InvalidArgumentException("`epiweeks`, and `locations` are all required")
 
         return self._create_call(
             "cdc/",
-            dict(auth=auth, epiweeks=epiweeks, locations=locations),
+            dict(epiweeks=epiweeks, locations=locations),
             [
                 EpidataFieldInfo("location", EpidataFieldType.text),
                 EpidataFieldInfo("epiweek", EpidataFieldType.epiweek),
@@ -500,17 +500,15 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def dengue_sensors(
-        self, auth: str, names: StringParam, locations: StringParam, epiweeks: EpiRangeParam
-    ) -> CALL_TYPE:
+    def dengue_sensors(self, names: StringParam, locations: StringParam, epiweeks: EpiRangeParam) -> CALL_TYPE:
         """Fetch Delphi's digital surveillance sensors."""
 
-        if auth is None or names is None or locations is None or epiweeks is None:
-            raise InvalidArgumentException("`auth`, `names`, `locations`, and `epiweeks` are all required")
+        if names is None or locations is None or epiweeks is None:
+            raise InvalidArgumentException("`names`, `locations`, and `epiweeks` are all required")
 
         return self._create_call(
             "dengue_sensors/",
-            dict(auth=auth, names=names, locations=locations, epiweeks=epiweeks),
+            dict(names=names, locations=locations, epiweeks=epiweeks),
             [
                 EpidataFieldInfo("name", EpidataFieldType.text),
                 EpidataFieldInfo("location", EpidataFieldType.text),
@@ -623,7 +621,6 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam,
         issues: Optional[EpiRangeParam] = None,
         lag: Optional[int] = None,
-        auth: Optional[str] = None,
     ) -> CALL_TYPE:
         if regions is None or epiweeks is None:
             raise InvalidArgumentException("`regions` and `epiweeks` are both required")
@@ -631,7 +628,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             raise InvalidArgumentException("`issues` and `lag` are mutually exclusive")
         return self._create_call(
             "fluview/",
-            dict(regions=regions, epiweeks=epiweeks, issues=issues, lag=lag, auth=auth),
+            dict(regions=regions, epiweeks=epiweeks, issues=issues, lag=lag),
             [
                 EpidataFieldInfo("release_date", EpidataFieldType.text),
                 EpidataFieldInfo("region", EpidataFieldType.text),
@@ -665,13 +662,13 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def ght(self, auth: str, locations: StringParam, epiweeks: EpiRangeParam, query: str) -> CALL_TYPE:
+    def ght(self, locations: StringParam, epiweeks: EpiRangeParam, query: str) -> CALL_TYPE:
         """Fetch Google Health Trends data."""
-        if auth is None or locations is None or epiweeks is None or query is None:
-            raise InvalidArgumentException("`auth`, `locations`, `epiweeks`, and `query` are all required")
+        if locations is None or epiweeks is None or query is None:
+            raise InvalidArgumentException("`locations`, `epiweeks`, and `query` are all required")
         return self._create_call(
             "ght/",
-            dict(auth=auth, locations=locations, epiweeks=epiweeks, query=query),
+            dict(locations=locations, epiweeks=epiweeks, query=query),
             [
                 EpidataFieldInfo("location", EpidataFieldType.text),
                 EpidataFieldInfo("epiweek", EpidataFieldType.epiweek),
@@ -704,25 +701,19 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def meta_afhsb(self, auth: str) -> CALL_TYPE:
+    def meta_afhsb(self) -> CALL_TYPE:
         """Fetch AFHSB metadata."""
-
-        if auth is None:
-            raise InvalidArgumentException("`auth` is required")
-
         return self._create_call(
             "meta_afhsb/",
-            dict(auth=auth),
+            dict(),
         )
 
-    def meta_norostat(self, auth: str) -> CALL_TYPE:
+    def meta_norostat(self) -> CALL_TYPE:
         """Fetch NoroSTAT metadata."""
 
-        if auth is None:
-            raise InvalidArgumentException("`auth` is required")
         return self._create_call(
             "meta_norostat/",
-            dict(auth=auth),
+            dict(),
         )
 
     def meta(self) -> CALL_TYPE:
@@ -776,14 +767,14 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def norostat(self, auth: str, location: str, epiweeks: EpiRangeParam) -> CALL_TYPE:
+    def norostat(self, location: str, epiweeks: EpiRangeParam) -> CALL_TYPE:
         """Fetch NoroSTAT data (point data, no min/max)."""
 
-        if auth is None or location is None or epiweeks is None:
-            raise InvalidArgumentException("`auth`, `location`, and `epiweeks` are all required")
+        if location is None or epiweeks is None:
+            raise InvalidArgumentException("`location`, and `epiweeks` are all required")
         return self._create_call(
             "norostat/",
-            dict(auth=auth, epiweeks=epiweeks, location=location),
+            dict(epiweeks=epiweeks, location=location),
             [
                 EpidataFieldInfo("release_date", EpidataFieldType.text),
                 EpidataFieldInfo("epiweek", EpidataFieldType.epiweek),
@@ -839,15 +830,15 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def quidel(self, auth: str, epiweeks: EpiRangeParam, locations: StringParam) -> CALL_TYPE:
+    def quidel(self, epiweeks: EpiRangeParam, locations: StringParam) -> CALL_TYPE:
         """Fetch Quidel data."""
 
-        if auth is None or epiweeks is None or locations is None:
-            raise InvalidArgumentException("`auth`, `epiweeks`, and `locations` are all required")
+        if epiweeks is None or locations is None:
+            raise InvalidArgumentException("`epiweeks`, and `locations` are all required")
 
         return self._create_call(
             "quidel/",
-            dict(auth=auth, epiweeks=epiweeks, locations=locations),
+            dict(epiweeks=epiweeks, locations=locations),
             [
                 EpidataFieldInfo("location", EpidataFieldType.text),
                 EpidataFieldInfo("epiweek", EpidataFieldType.epiweek),
@@ -855,14 +846,14 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def sensors(self, auth: str, names: StringParam, locations: StringParam, epiweeks: EpiRangeParam) -> CALL_TYPE:
+    def sensors(self, names: StringParam, locations: StringParam, epiweeks: EpiRangeParam) -> CALL_TYPE:
         """Fetch Delphi's digital surveillance sensors."""
 
-        if auth is None or names is None or locations is None or epiweeks is None:
-            raise InvalidArgumentException("`auth`, `names`, `locations`, and `epiweeks` are all required")
+        if names is None or locations is None or epiweeks is None:
+            raise InvalidArgumentException("`names`, `locations`, and `epiweeks` are all required")
         return self._create_call(
             "sensors/",
-            dict(auth=auth, names=names, locations=locations, epiweeks=epiweeks),
+            dict(names=names, locations=locations, epiweeks=epiweeks),
             [
                 EpidataFieldInfo("name", EpidataFieldType.text),
                 EpidataFieldInfo("location", EpidataFieldType.text),
@@ -873,20 +864,19 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
 
     def twitter(
         self,
-        auth: str,
         locations: StringParam,
         dates: Optional[EpiRangeParam] = None,
         epiweeks: Optional[EpiRangeParam] = None,
     ) -> CALL_TYPE:
         """Fetch HealthTweets data."""
 
-        if auth is None or locations is None:
-            raise InvalidArgumentException("`auth` and `locations` are both required")
+        if locations is None:
+            raise InvalidArgumentException("`locations` is required")
         if not (dates is None) ^ (epiweeks is None):
             raise InvalidArgumentException("exactly one of `dates` and `epiweeks` is required")
         return self._create_call(
             "twitter/",
-            dict(auth=auth, locations=locations, dates=dates, epiweeks=epiweeks),
+            dict(locations=locations, dates=dates, epiweeks=epiweeks),
             [
                 EpidataFieldInfo("location", EpidataFieldType.text),
                 EpidataFieldInfo("date", EpidataFieldType.date)

--- a/delphi_epidata/_model.py
+++ b/delphi_epidata/_model.py
@@ -120,6 +120,7 @@ class AEpiDataCall:
     """
 
     _base_url: Final[str]
+    _api_key: Final[str]
     _endpoint: Final[str]
     _params: Final[Mapping[str, Union[None, EpiRangeLike, Iterable[EpiRangeLike]]]]
     meta: Final[Sequence[EpidataFieldInfo]]
@@ -128,11 +129,13 @@ class AEpiDataCall:
     def __init__(
         self,
         base_url: str,
+        api_key: str,
         endpoint: str,
         params: Mapping[str, Union[None, EpiRangeLike, Iterable[EpiRangeLike]]],
         meta: Optional[Sequence[EpidataFieldInfo]] = None,
     ) -> None:
         self._base_url = base_url
+        self._api_key = api_key
         self._endpoint = endpoint
         self._params = params
         self.meta = meta or []
@@ -149,6 +152,7 @@ class AEpiDataCall:
             all_params["format"] = format_type
         if fields:
             all_params["fields"] = fields
+        all_params["token"] = self._api_key
         return {k: format_list(v) for k, v in all_params.items() if v is not None}
 
     def request_arguments(
@@ -182,7 +186,7 @@ class AEpiDataCall:
         u, p = self.request_arguments(format_type, fields)
         query = urlencode(p)
         if query:
-            return f"{u}?{query}"
+            return f"{u}?{query}&token={self._api_key}"
         return u
 
     def __repr__(self) -> str:

--- a/smoke_covid_test.py
+++ b/smoke_covid_test.py
@@ -1,6 +1,6 @@
 from delphi_epidata.requests import CovidcastEpidata, EpiRange
 
-epidata = CovidcastEpidata()
+epidata = CovidcastEpidata("test")
 print(list(epidata.source_names))
 apicall = epidata[("fb-survey", "smoothed_cli")].call(
     "nation",

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,7 +1,8 @@
 from datetime import date
 from delphi_epidata.requests import Epidata, EpiRange
 
-apicall = Epidata.covidcast("fb-survey", "smoothed_cli", "day", "nation", EpiRange(20210405, 20210410), "us")
+epidata = Epidata("test")
+apicall = epidata.covidcast("fb-survey", "smoothed_cli", "day", "nation", EpiRange(20210405, 20210410), "us")
 
 print(apicall)
 
@@ -21,9 +22,9 @@ print(df.dtypes)
 for row in apicall.iter():
     print(row)
 
-StagingEpidata = Epidata.with_base_url("https://staging.delphi.cmu.edu/epidata/")
+stagingEpidata = epidata.with_base_url("https://staging.delphi.cmu.edu/epidata/")
 
-df = StagingEpidata.covidcast(
+df = stagingEpidata.covidcast(
     "fb-survey", "smoothed_cli", "day", "nation", EpiRange(date(2021, 4, 5), date(2021, 4, 10)), "*"
 ).df()
 print(df.shape)

--- a/smoke_test_async.py
+++ b/smoke_test_async.py
@@ -3,7 +3,8 @@ from delphi_epidata.async_requests import Epidata
 
 
 async def main() -> None:
-    apicall = Epidata.covidcast("fb-survey", "smoothed_cli", "day", "nation", Epidata.range(20210405, 20210410), "us")
+    epidata = Epidata("test")
+    apicall = epidata.covidcast("fb-survey", "smoothed_cli", "day", "nation", Epidata.range(20210405, 20210410), "us")
     classic = await apicall.classic()
     print(classic)
 


### PR DESCRIPTION
breaking change: 

there is no anonymous epidata instance anymore but it needs to be initiated with an API key first

```py
epidata = Epidata("test")
apicall = epidata.covidcast("fb-survey", "smoothed_cli", "day", "nation", Epidata.range(20210405, 20210410), "us")
apicall.classic()
```
