### PR TITLE
refactor: simplify classes

### DIFF
--- a/epidatpy/_covidcast.py
+++ b/epidatpy/_covidcast.py
@@ -5,8 +5,8 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import Field, InitVar, asdict, dataclass, field, fields
 from functools import cached_property
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Generic,
     Literal,
     get_args,
     overload,
@@ -15,7 +15,6 @@ from typing import (
 from pandas import DataFrame
 
 from ._model import (
-    CALL_TYPE,
     EpidataFieldInfo,
     EpidataFieldType,
     EpiRangeParam,
@@ -23,6 +22,9 @@ from ._model import (
     InvalidArgumentException,
     TimeType,
 )
+
+if TYPE_CHECKING:
+    from .request import EpiDataCall
 
 
 @dataclass
@@ -73,10 +75,10 @@ def define_covidcast_fields() -> list[EpidataFieldInfo]:
 
 
 @dataclass
-class DataSignal(Generic[CALL_TYPE]):
+class DataSignal:
     """represents a COVIDcast data signal"""
 
-    _create_call: Callable[[Mapping[str, EpiRangeParam | None]], CALL_TYPE]
+    _create_call: Callable[[Mapping[str, EpiRangeParam | None]], EpiDataCall]
 
     source: str
     signal: str
@@ -150,7 +152,7 @@ class DataSignal(Generic[CALL_TYPE]):
         as_of: None | str | int = None,
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch Delphi's COVID-19 Surveillance Streams"""
         if any(v is None for v in (geo_type, geo_values, time_values)):
             raise InvalidArgumentException("`geo_type`, `time_values`, and `geo_values` are all required")
@@ -179,16 +181,16 @@ class DataSignal(Generic[CALL_TYPE]):
         as_of: None | str | int = None,
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch Delphi's COVID-19 Surveillance Streams"""
         return self.call(geo_type, geo_values, time_values, as_of, issues, lag)
 
 
 @dataclass
-class DataSource(Generic[CALL_TYPE]):
+class DataSource:
     """represents a COVIDcast data source"""
 
-    _create_call: InitVar[Callable[[Mapping[str, EpiRangeParam | None]], CALL_TYPE]]
+    _create_call: InitVar[Callable[[Mapping[str, EpiRangeParam | None]], EpiDataCall]]
 
     source: str
     db_source: str
@@ -201,7 +203,7 @@ class DataSource(Generic[CALL_TYPE]):
 
     signals: Sequence[DataSignal] = field(default_factory=list)
 
-    def __post_init__(self, _create_call: Callable[[Mapping[str, EpiRangeParam | None]], CALL_TYPE]) -> None:
+    def __post_init__(self, _create_call: Callable[[Mapping[str, EpiRangeParam | None]], EpiDataCall]) -> None:
         self.link = [
             WebLink(alt=link["alt"], href=link["href"]) if isinstance(link, dict) else link for link in self.link
         ]
@@ -236,16 +238,14 @@ class DataSource(Generic[CALL_TYPE]):
 
 
 @dataclass
-class CovidcastDataSources(Generic[CALL_TYPE]):
+class CovidcastDataSources:
     """COVIDcast data source helper."""
 
-    sources: Sequence[DataSource[CALL_TYPE]]
-    _source_by_name: dict[str, DataSource[CALL_TYPE]] = field(init=False, default_factory=dict)
-    _signals_by_key: OrderedDict[tuple[str, str], DataSignal[CALL_TYPE]] = field(
-        init=False, default_factory=OrderedDict
-    )
+    sources: Sequence[DataSource]
+    _source_by_name: dict[str, DataSource] = field(init=False, default_factory=dict)
+    _signals_by_key: OrderedDict[tuple[str, str], DataSignal] = field(init=False, default_factory=OrderedDict)
 
-    _create_call: Callable[[Mapping[str, EpiRangeParam | None]], CALL_TYPE]
+    _create_call: Callable[[Mapping[str, EpiRangeParam | None]], EpiDataCall]
 
     def __post_init__(self) -> None:
         self._source_by_name = {s.source: s for s in self.sources}
@@ -373,12 +373,12 @@ class CovidcastDataSources(Generic[CALL_TYPE]):
         return DataSignal.to_df(self._signals_by_key.values())
 
     @overload
-    def __getitem__(self, source: str, /) -> DataSource[CALL_TYPE]: ...
+    def __getitem__(self, source: str, /) -> DataSource: ...
 
     @overload
-    def __getitem__(self, source_signal: tuple[str, str], /) -> DataSignal[CALL_TYPE]: ...
+    def __getitem__(self, source_signal: tuple[str, str], /) -> DataSignal: ...
 
-    def __getitem__(self, source_signal: str | tuple[str, str]) -> DataSource[CALL_TYPE] | DataSignal[CALL_TYPE]:
+    def __getitem__(self, source_signal: str | tuple[str, str]) -> DataSource | DataSignal:
         if isinstance(source_signal, str):
             r = self._source_by_name.get(source_signal)
             assert r is not None
@@ -390,7 +390,7 @@ class CovidcastDataSources(Generic[CALL_TYPE]):
     @staticmethod
     def create(
         meta: list[dict],
-        create_call: Callable[[Mapping[str, EpiRangeParam | None]], CALL_TYPE],
+        create_call: Callable[[Mapping[str, EpiRangeParam | None]], EpiDataCall],
     ) -> CovidcastDataSources:
         source_fields = fields(DataSource)
         sources = [DataSource(_create_call=create_call, **_limit_fields(k, source_fields)) for k in meta]

--- a/epidatpy/_endpoints.py
+++ b/epidatpy/_endpoints.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import warnings
-from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from datetime import date
 from typing import (
-    Generic,
+    TYPE_CHECKING,
     Literal,
 )
 
@@ -13,7 +12,6 @@ from epiweeks import Week
 
 from ._covidcast import GeoType, TimeType, define_covidcast_fields
 from ._model import (
-    CALL_TYPE,
     ApiVersion,
     CastPostFilter,
     EpidataFieldInfo,
@@ -24,8 +22,12 @@ from ._model import (
     InvalidArgumentException,
     ParamType,
     StringParam,
+    format_list,
 )
 from ._parse import parse_api_date, parse_user_date_or_week, validate_report_time_query
+
+if TYPE_CHECKING:
+    from .request import EpiDataCall
 
 
 def get_wildcard_equivalent_dates(time_value: EpiRangeParam, time_type: Literal["day", "week"]) -> EpiRangeParam:
@@ -37,10 +39,9 @@ def get_wildcard_equivalent_dates(time_value: EpiRangeParam, time_type: Literal[
     return time_value
 
 
-class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
+class AEpiDataEndpoints:
     """epidata endpoint list and fetcher"""
 
-    @abstractmethod
     def _create_call(
         self,
         endpoint: str,
@@ -49,7 +50,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         only_supports_classic: bool = False,
         api_version: ApiVersion = "classic",
         post_filter: CastPostFilter | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         raise NotImplementedError()
 
     def pvt_cdc(
@@ -57,7 +58,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         auth: str,
         locations: StringParam,
         epiweeks: EpiRangeParam = "*",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch CDC total and by topic webpage visits.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/cdc.html>
@@ -102,7 +103,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         city: str | None = None,
         zip: str | None = None,
         fips_code: str | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Helper for finding COVID hospitalization facilities.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covid_hosp_facility_lookup.html>
@@ -158,7 +159,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         hospital_pks: StringParam,
         collection_weeks: EpiRangeParam = "*",
         publication_dates: EpiRangeParam | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch COVID hospitalizations by facility.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covid_hosp_facility.html>
@@ -330,7 +331,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         dates: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         as_of: None | int | str = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch COVID hospitalizations by state.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covid_hosp.html>
@@ -441,7 +442,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pub_covidcast_meta(self) -> CALL_TYPE:
+    def pub_covidcast_meta(self) -> EpiDataCall:
         """Fetch COVIDcast surveillance stream metadata.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_meta.html>
@@ -454,7 +455,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
 
         Returns
         -------
-        CALL_TYPE
+        EpiDataCall
             A ``EpiDataCall`` object containing the following information:
 
             ``data_source``
@@ -546,7 +547,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         as_of: None | str | int = None,
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch Delphi's COVID-19 Surveillance Streams.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>
@@ -608,7 +609,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             define_covidcast_fields(),
         )
 
-    def pub_delphi(self, system: str, epiweek: int | str) -> CALL_TYPE:
+    def pub_delphi(self, system: str, epiweek: int | str) -> EpiDataCall:
         """Fetch Delphi's ILINet outpatient doctor visits forecasts.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/delphi.html>
@@ -634,7 +635,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             only_supports_classic=True,
         )
 
-    def pub_dengue_nowcast(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> CALL_TYPE:
+    def pub_dengue_nowcast(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> EpiDataCall:
         """Fetch Delphi's PAHO dengue nowcasts (North and South America).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/dengue_nowcast.html>
@@ -669,7 +670,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         names: StringParam,
         locations: StringParam,
         epiweeks: EpiRangeParam = "*",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch PAHO dengue digital surveillance sensors (North and South America).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/dengue_sensors.html>
@@ -715,7 +716,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch ECDC ILI incidence (Europe).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/ecdc_ili.html>
@@ -764,7 +765,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch CDC FluSurv flu hospitalizations.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/flusurv.html>
@@ -848,7 +849,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch CDC FluView flu tests from clinical labs.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/fluview_clinical.html>
@@ -893,7 +894,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pub_fluview_meta(self) -> CALL_TYPE:
+    def pub_fluview_meta(self) -> EpiDataCall:
         """Fetch Metadata for the FluView endpoint.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/fluview_meta.html>
@@ -915,7 +916,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
         auth: str | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch CDC FluView ILINet outpatient doctor visits.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/fluview.html>
@@ -979,7 +980,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pub_gft(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> CALL_TYPE:
+    def pub_gft(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> EpiDataCall:
         """Fetch Google Flu Trends flu search volume.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/gft.html>
@@ -1018,7 +1019,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         locations: StringParam,
         epiweeks: EpiRangeParam = "*",
         query: str = "",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch Google Health Trends data.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/ght.html>
@@ -1065,7 +1066,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch KCDC ILI incidence (Korea).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/kcdc_ili.html>
@@ -1111,7 +1112,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pvt_meta_norostat(self, auth: str) -> CALL_TYPE:
+    def pvt_meta_norostat(self, auth: str) -> EpiDataCall:
         """Fetch NoroSTAT metadata.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/norostat_meta.html>
@@ -1129,7 +1130,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             only_supports_classic=True,
         )
 
-    def pub_meta(self) -> CALL_TYPE:
+    def pub_meta(self) -> EpiDataCall:
         """Fetch API metadata.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/meta.html>
@@ -1140,7 +1141,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             only_supports_classic=True,
         )
 
-    def pub_nidss_dengue(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> CALL_TYPE:
+    def pub_nidss_dengue(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> EpiDataCall:
         """Fetch NIDSS dengue data (Taiwan).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/nidss_dengue.html>
@@ -1174,7 +1175,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch NIDSS flu data (Taiwan).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/nidss_flu.html>
@@ -1215,7 +1216,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pvt_norostat(self, auth: str, location: str, epiweeks: EpiRangeParam = "*") -> CALL_TYPE:
+    def pvt_norostat(self, auth: str, location: str, epiweeks: EpiRangeParam = "*") -> EpiDataCall:
         """Fetch NoroSTAT data (point data, no min/max).
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/norostat.html>
@@ -1247,7 +1248,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pub_nowcast(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> CALL_TYPE:
+    def pub_nowcast(self, locations: StringParam, epiweeks: EpiRangeParam = "*") -> EpiDataCall:
         """Fetch Delphi's wILI nowcast.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/ili_nearby_nowcast.html>
@@ -1282,7 +1283,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         epiweeks: EpiRangeParam = "*",
         issues: EpiRangeParam | None = None,
         lag: int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch PAHO Dengue data.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/paho_dengue.html>
@@ -1328,7 +1329,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             ],
         )
 
-    def pvt_quidel(self, auth: str, locations: StringParam, epiweeks: EpiRangeParam = "*") -> CALL_TYPE:
+    def pvt_quidel(self, auth: str, locations: StringParam, epiweeks: EpiRangeParam = "*") -> EpiDataCall:
         """Fetch Quidel data.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/quidel.html>
@@ -1366,7 +1367,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         names: StringParam,
         locations: StringParam,
         epiweeks: EpiRangeParam = "*",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch Delphi's digital surveillance sensors.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/digital_surveillance_sensors.html>
@@ -1412,7 +1413,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         locations: StringParam,
         time_type: Literal["day", "week"],
         time_values: EpiRangeParam = "*",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch HealthTweets data.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/twitter.html>
@@ -1472,7 +1473,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         time_values: EpiRangeParam = "*",
         hours: IntParam | None = None,
         language: str = "en",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch Wikipedia access data.
 
         API docs: <https://cmu-delphi.github.io/delphi-epidata/api/wiki.html>
@@ -1535,7 +1536,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         reference_time: EpiRangeParam = "*",
         fill_method: str | None = None,
         snapshot_date: str | date | int | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch a snapshot of CAST-API signals as they appeared on `snapshot_date`.
 
         `snapshot_date=None` returns the latest available version. `geo_values`
@@ -1550,7 +1551,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
             if parsed is None:
                 raise InvalidArgumentException(f"Invalid `snapshot_date` value: {snapshot_date!r}")
             snapshot_date_str = parsed.strftime("%Y-%m-%d")
-        signal_str = signals if isinstance(signals, str) else ",".join(signals)
+        signal_str = format_list(signals)
 
         return self._create_call(
             "snapshot/",
@@ -1575,7 +1576,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         reference_time: EpiRangeParam = "*",
         fill_method: str | None = None,
         report_time: str | date | EpiRange | None = "*",
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Fetch the full report-time history of CAST-API signals.
 
         `report_time` accepts an exact date, an operator-prefixed string
@@ -1585,7 +1586,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         """
         report_time_str = validate_report_time_query(report_time)
 
-        signal_str = signals if isinstance(signals, str) else ",".join(signals)
+        signal_str = format_list(signals)
 
         return self._create_call(
             "archive/",
@@ -1615,7 +1616,7 @@ class AEpiDataEndpoints(ABC, Generic[CALL_TYPE]):
         fill_method: str | None = None,
         snapshot_date: str | date | int | None = None,
         report_time: str | date | EpiRange | None = None,
-    ) -> CALL_TYPE:
+    ) -> EpiDataCall:
         """Router for CAST-API queries.
 
         Dispatches to :meth:`epidata_archive` when ``report_time`` is

--- a/epidatpy/_model.py
+++ b/epidatpy/_model.py
@@ -10,6 +10,7 @@ from typing import (
     Literal,
     TypedDict,
     Union,
+    cast,
 )
 
 if TYPE_CHECKING:
@@ -64,7 +65,10 @@ def format_item(value: EpiRangeLike) -> str:
 def format_list(values: EpiRangeParam) -> str:
     """Turn a list/tuple of values/ranges into a comma-separated string."""
     if isinstance(values, Sequence) and not isinstance(values, str):
-        return ",".join([format_item(value) for value in values])
+        # ty drops the element type when narrowing a Sequence via isinstance,
+        # widening it to `object`; cast restores what we already know here.
+        seq = cast("Sequence[EpiRangeLike]", values)
+        return ",".join([format_item(value) for value in seq])
     return format_item(values)
 
 

--- a/epidatpy/_model.py
+++ b/epidatpy/_model.py
@@ -1,32 +1,23 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import date
 from enum import Enum
-from os import environ
 from typing import (
     TYPE_CHECKING,
     Final,
     Literal,
     TypedDict,
-    TypeVar,
     Union,
-    cast,
 )
 
 if TYPE_CHECKING:
     from pandas import DataFrame
-from urllib.parse import urlencode
 
 from epiweeks import Week
 
-from ._parse import (
-    parse_api_date,
-    parse_api_date_or_week,
-    parse_api_week,
-    parse_user_date_or_week,
-)
+from ._parse import parse_user_date_or_week
 
 GeoType = Literal["nation", "msa", "hrr", "hhs", "state", "county"]
 TimeType = Literal["day", "week"]
@@ -37,7 +28,6 @@ EpiRangeParam = Union[EpiRangeLike, Sequence[EpiRangeLike]]
 StringParam = Union[str, Sequence[str]]
 IntParam = Union[int, Sequence[int]]
 ParamType = Union[StringParam, IntParam, EpiRangeParam]
-CALL_TYPE = TypeVar("CALL_TYPE")
 
 
 class EpiDataResponse(TypedDict):
@@ -54,7 +44,7 @@ def format_date(d: EpiDateLike) -> str:
         return d.strftime("%Y%m%d")
     if isinstance(d, Week):
         # YYYYww
-        return cast(str, d.cdcformat())
+        return d.cdcformat()
     return str(d)
 
 
@@ -145,126 +135,6 @@ CastPostFilter = tuple[
 ]
 
 
-class AEpiDataCall:
-    """base epidata call class"""
-
-    _base_url: Final[str]
-    _endpoint: Final[str]
-    _params: Final[Mapping[str, EpiRangeParam | None]]
-    _api_version: Final[ApiVersion]
-    _post_filter: Final[CastPostFilter | None]
-    meta: Final[Sequence[EpidataFieldInfo]]
-    meta_by_name: Final[Mapping[str, EpidataFieldInfo]]
-    only_supports_classic: Final[bool]
-    use_cache: Final[bool]
-
-    def __init__(
-        self,
-        base_url: str,
-        endpoint: str,
-        params: Mapping[str, EpiRangeParam | None],
-        meta: Sequence[EpidataFieldInfo] | None = None,
-        only_supports_classic: bool = False,
-        use_cache: bool | None = None,
-        cache_max_age_days: int | None = None,
-        api_version: ApiVersion = "classic",
-        post_filter: CastPostFilter | None = None,
-    ) -> None:
-        self._base_url = base_url
-        self._endpoint = endpoint
-        self._params = params
-        self._api_version = api_version
-        self._post_filter = post_filter
-        self.only_supports_classic = only_supports_classic
-        self.meta = meta or []
-        self.meta_by_name = {k.name: k for k in self.meta}
-        # Set the use_cache value from the constructor if present.
-        # Otherwise check the USE_EPIDATPY_CACHE variable, accepting various "truthy" values.
-        self.use_cache = (
-            use_cache
-            if use_cache is not None
-            else (environ.get("USE_EPIDATPY_CACHE", "").lower() in ["true", "t", "1"])
-        )
-        # Set cache_max_age_days from the constructor, fall back to environment variable.
-        if cache_max_age_days:
-            self.cache_max_age_days = cache_max_age_days
-        else:
-            env_days = environ.get("EPIDATPY_CACHE_MAX_AGE_DAYS", "7")
-            if env_days.isdigit():
-                self.cache_max_age_days = int(env_days)
-            else:  # handle string / negative / invalid enviromment variable
-                self.cache_max_age_days = 7
-
-    def _verify_parameters(self) -> None:
-        # hook for verifying parameters before sending
-        pass
-
-    def _formatted_parameters(
-        self,
-        fields: Sequence[str] | None = None,
-    ) -> Mapping[str, str]:
-        """Format this call into a [URL, Params] tuple"""
-        all_params = dict(self._params)
-        if fields:
-            all_params["fields"] = fields
-        return {k: format_list(v) for k, v in all_params.items() if v is not None}
-
-    def request_arguments(
-        self,
-        fields: Sequence[str] | None = None,
-    ) -> tuple[str, Mapping[str, str]]:
-        """Format this call into a [URL, Params] tuple"""
-        formatted_params = self._formatted_parameters(fields)
-        full_url = add_endpoint_to_url(self._base_url, self._endpoint)
-        return full_url, formatted_params
-
-    def request_url(
-        self,
-        fields: Sequence[str] | None = None,
-    ) -> str:
-        """Format this call into a full HTTP request url with encoded parameters"""
-        self._verify_parameters()
-        u, p = self.request_arguments(fields)
-        query = urlencode(p)
-        if query:
-            return f"{u}?{query}"
-        return u
-
-    def __repr__(self) -> str:
-        return str(self)
-
-    def __str__(self) -> str:
-        return f"EpiDataCall(endpoint={self._endpoint}, params={self._formatted_parameters()})"
-
-    def _parse_value(
-        self,
-        key: str,
-        value: str | float | int | None,
-        disable_date_parsing: bool | None = False,
-    ) -> str | float | int | date | None:
-        meta = self.meta_by_name.get(key)
-        if not meta or value is None:
-            return value
-        if meta.type == EpidataFieldType.date_or_epiweek and not disable_date_parsing:
-            return parse_api_date_or_week(value)
-        if meta.type == EpidataFieldType.date and not disable_date_parsing:
-            return parse_api_date(value)
-        if meta.type == EpidataFieldType.epiweek and not disable_date_parsing:
-            return parse_api_week(value)
-        if meta.type == EpidataFieldType.bool:
-            return bool(value)
-        return value
-
-    def _parse_row(
-        self,
-        row: Mapping[str, str | float | int | None],
-        disable_date_parsing: bool | None = False,
-    ) -> Mapping[str, str | float | int | date | None]:
-        if not self.meta:
-            return row
-        return {k: self._parse_value(k, v, disable_date_parsing) for k, v in row.items()}
-
-
 def cast_filter(
     df: DataFrame,
     geo_values: str | Sequence[str] = "*",
@@ -310,7 +180,7 @@ def _filter_by_timeset(
         return df[(values >= lo) & (values <= hi)]
 
     if isinstance(timeset, (str, int, date, Week)):
-        wanted = [to_datetime(format_item(timeset))]
+        wanted = to_datetime([format_item(timeset)])
     else:
-        wanted = [to_datetime(format_item(v)) for v in timeset]
+        wanted = to_datetime([format_item(v) for v in timeset])
     return df[values.isin(wanted)]

--- a/epidatpy/request.py
+++ b/epidatpy/request.py
@@ -127,15 +127,11 @@ class EpiDataCall:
             if use_cache is not None
             else (environ.get("USE_EPIDATPY_CACHE", "").lower() in ["true", "t", "1"])
         )
-        if cache_max_age_days:
+        if cache_max_age_days is not None:
             self.cache_max_age_days = cache_max_age_days
         else:
             env_days = environ.get("EPIDATPY_CACHE_MAX_AGE_DAYS", "7")
             self.cache_max_age_days = int(env_days) if env_days.isdigit() else 7
-
-    def _verify_parameters(self) -> None:
-        # hook for verifying parameters before sending
-        pass
 
     def _formatted_parameters(
         self,
@@ -160,7 +156,6 @@ class EpiDataCall:
         fields: Sequence[str] | None = None,
     ) -> str:
         """Format this call into a full HTTP request url with encoded parameters."""
-        self._verify_parameters()
         u, p = self.request_arguments(fields)
         query = urlencode(p)
         if query:
@@ -253,7 +248,6 @@ class EpiDataCall:
         disable_type_parsing: bool | None = False,
     ) -> EpiDataResponse:
         """Request and parse epidata in CLASSIC message format."""
-        self._verify_parameters()
         try:
             if self.use_cache:
                 with Cache(CACHE_DIRECTORY) as cache:
@@ -297,7 +291,6 @@ class EpiDataCall:
         """Request and parse epidata as a pandas data frame"""
         if self.only_supports_classic:
             raise OnlySupportsClassicFormatException()
-        self._verify_parameters()
 
         if self.use_cache:
             with Cache(CACHE_DIRECTORY) as cache:

--- a/epidatpy/request.py
+++ b/epidatpy/request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Mapping, Sequence
+from datetime import date
 from io import StringIO
 from os import environ
 from typing import (
@@ -9,6 +10,7 @@ from typing import (
     Final,
     cast,
 )
+from urllib.parse import urlencode
 
 from appdirs import user_cache_dir
 from diskcache import Cache
@@ -22,7 +24,6 @@ from ._constants import BASE_URL, CAST_BASE_URL, HTTP_HEADERS
 from ._covidcast import CovidcastDataSources, define_covidcast_fields
 from ._endpoints import AEpiDataEndpoints
 from ._model import (
-    AEpiDataCall,
     ApiVersion,
     CastPostFilter,
     EpidataFieldInfo,
@@ -32,8 +33,14 @@ from ._model import (
     OnlySupportsClassicFormatException,
     add_endpoint_to_url,
     cast_filter,
+    format_list,
 )
-from ._parse import fields_to_predicate
+from ._parse import (
+    fields_to_predicate,
+    parse_api_date,
+    parse_api_date_or_week,
+    parse_api_week,
+)
 
 # Make the linter happy about the unused variables
 CACHE_DIRECTORY = user_cache_dir(appname="epidatpy", appauthor="delphi")
@@ -77,10 +84,19 @@ def _request_with_retry(
         return call_impl(s)
 
 
-class EpiDataCall(AEpiDataCall):
+class EpiDataCall:
     """epidata call representation"""
 
+    _base_url: Final[str]
+    _endpoint: Final[str]
+    _params: Final[Mapping[str, EpiRangeParam | None]]
+    _api_version: Final[ApiVersion]
+    _post_filter: Final[CastPostFilter | None]
     _session: Final[Session | None]
+    meta: Final[Sequence[EpidataFieldInfo]]
+    meta_by_name: Final[Mapping[str, EpidataFieldInfo]]
+    only_supports_classic: Final[bool]
+    use_cache: Final[bool]
 
     def __init__(
         self,
@@ -95,18 +111,95 @@ class EpiDataCall(AEpiDataCall):
         api_version: ApiVersion = "classic",
         post_filter: CastPostFilter | None = None,
     ) -> None:
-        super().__init__(
-            base_url,
-            endpoint,
-            params,
-            meta,
-            only_supports_classic,
-            use_cache,
-            cache_max_age_days,
-            api_version=api_version,
-            post_filter=post_filter,
-        )
+        self._base_url = base_url
+        self._endpoint = endpoint
+        self._params = params
+        self._api_version = api_version
+        self._post_filter = post_filter
         self._session = session
+        self.only_supports_classic = only_supports_classic
+        self.meta = meta or []
+        self.meta_by_name = {k.name: k for k in self.meta}
+        # Set use_cache from the constructor if present; otherwise check
+        # USE_EPIDATPY_CACHE, accepting various "truthy" values.
+        self.use_cache = (
+            use_cache
+            if use_cache is not None
+            else (environ.get("USE_EPIDATPY_CACHE", "").lower() in ["true", "t", "1"])
+        )
+        if cache_max_age_days:
+            self.cache_max_age_days = cache_max_age_days
+        else:
+            env_days = environ.get("EPIDATPY_CACHE_MAX_AGE_DAYS", "7")
+            self.cache_max_age_days = int(env_days) if env_days.isdigit() else 7
+
+    def _verify_parameters(self) -> None:
+        # hook for verifying parameters before sending
+        pass
+
+    def _formatted_parameters(
+        self,
+        fields: Sequence[str] | None = None,
+    ) -> Mapping[str, str]:
+        all_params = dict(self._params)
+        if fields:
+            all_params["fields"] = fields
+        return {k: format_list(v) for k, v in all_params.items() if v is not None}
+
+    def request_arguments(
+        self,
+        fields: Sequence[str] | None = None,
+    ) -> tuple[str, Mapping[str, str]]:
+        """Format this call into a (URL, params) tuple."""
+        formatted_params = self._formatted_parameters(fields)
+        full_url = add_endpoint_to_url(self._base_url, self._endpoint)
+        return full_url, formatted_params
+
+    def request_url(
+        self,
+        fields: Sequence[str] | None = None,
+    ) -> str:
+        """Format this call into a full HTTP request url with encoded parameters."""
+        self._verify_parameters()
+        u, p = self.request_arguments(fields)
+        query = urlencode(p)
+        if query:
+            return f"{u}?{query}"
+        return u
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __str__(self) -> str:
+        return f"EpiDataCall(endpoint={self._endpoint}, params={self._formatted_parameters()})"
+
+    def _parse_value(
+        self,
+        key: str,
+        value: str | float | int | None,
+        disable_date_parsing: bool | None = False,
+    ) -> str | float | int | date | None:
+        meta = self.meta_by_name.get(key)
+        if not meta or value is None:
+            return value
+        if meta.type == EpidataFieldType.date_or_epiweek and not disable_date_parsing:
+            return parse_api_date_or_week(value)
+        if meta.type == EpidataFieldType.date and not disable_date_parsing:
+            return parse_api_date(value)
+        if meta.type == EpidataFieldType.epiweek and not disable_date_parsing:
+            return parse_api_week(value)
+        if meta.type == EpidataFieldType.bool:
+            return bool(value)
+        return value
+
+    def _parse_row(
+        self,
+        row: Mapping[str, str | float | int | None],
+        disable_date_parsing: bool | None = False,
+    ) -> Mapping[str, str | float | int | date | None]:
+        if not self.meta:
+            return row
+        return {k: self._parse_value(k, v, disable_date_parsing) for k, v in row.items()}
 
     def with_base_url(self, base_url: str) -> EpiDataCall:
         return EpiDataCall(
@@ -114,10 +207,10 @@ class EpiDataCall(AEpiDataCall):
             self._session,
             self._endpoint,
             self._params,
-            self.meta,
-            self.only_supports_classic,
-            self.use_cache,
-            self.cache_max_age_days,
+            meta=self.meta,
+            only_supports_classic=self.only_supports_classic,
+            use_cache=self.use_cache,
+            cache_max_age_days=self.cache_max_age_days,
             api_version=self._api_version,
             post_filter=self._post_filter,
         )
@@ -128,10 +221,10 @@ class EpiDataCall(AEpiDataCall):
             session,
             self._endpoint,
             self._params,
-            self.meta,
-            self.only_supports_classic,
-            self.use_cache,
-            self.cache_max_age_days,
+            meta=self.meta,
+            only_supports_classic=self.only_supports_classic,
+            use_cache=self.use_cache,
+            cache_max_age_days=self.cache_max_age_days,
             api_version=self._api_version,
             post_filter=self._post_filter,
         )
@@ -222,7 +315,8 @@ class EpiDataCall(AEpiDataCall):
             if body.strip():
                 df = read_csv(StringIO(body), dtype=str)
                 # Keep only fields in meta that exist in the response, in meta order.
-                cols_in_df = [c for c in columns if c in df.columns]
+                df_cols = set(df.columns)
+                cols_in_df = [c for c in columns if c in df_cols]
                 df = df[cols_in_df] if cols_in_df else df
             else:
                 df = DataFrame(columns=columns or None)
@@ -296,7 +390,7 @@ class EpiDataCall(AEpiDataCall):
         return df
 
 
-class EpiDataContext(AEpiDataEndpoints[EpiDataCall]):
+class EpiDataContext(AEpiDataEndpoints):
     """sync epidata call class"""
 
     _base_url: Final[str]
@@ -381,7 +475,7 @@ def CovidcastEpidata(
     session: Session | None = None,
     use_cache: bool | None = None,
     cache_max_age_days: int | None = None,
-) -> CovidcastDataSources[EpiDataCall]:
+) -> CovidcastDataSources:
     url = add_endpoint_to_url(base_url, "covidcast/meta")
     meta_data_res = _request_with_retry(url, {}, session, False)
     meta_data_res.raise_for_status()


### PR DESCRIPTION
Remove the `Generic[CALL_TYPE]` abstraction and just use `EpidataCall` everywhere. Leftovers from Generics over EpidataCall and AsyncEpidataCall, which we don't use anymore.

More context on when we removed async support:
https://github.com/cmu-delphi/epidatpy/issues/30